### PR TITLE
Persistor uses internal state to decide file persistance

### DIFF
--- a/Modules/PhotoAnalyzer/image_processor.py
+++ b/Modules/PhotoAnalyzer/image_processor.py
@@ -63,6 +63,8 @@ class ImageTextSearch:
 
             empty_core_data[attr] = value
 
+        if debug.LOCAL_DEBUG:
+            debug.show_full_data(empty_core_data)
         return empty_core_data
 
     def analyze(self):

--- a/Modules/PhotoAnalyzer/image_processor.py
+++ b/Modules/PhotoAnalyzer/image_processor.py
@@ -6,7 +6,7 @@ import sys
 from ..shared         import GlobalVariables
 from ..shared         import GlobalConstants
 from ..image_data     import ImageData, Core
-from ..debug          import ImageTextSearch as debug
+from ..debug          import ImageProcessor as debug
 
 # set the path to the tesseract package
 pytesseract.pytesseract.tesseract_cmd = GlobalConstants.PYTESSERACT_LOCATION
@@ -16,6 +16,9 @@ debug = debug()
 
 def image_data_from_image(image):
     image_location = GlobalVariables.IMAGE_LOCATION + "/" + image
+
+    if debug.LOCAL_DEBUG:
+        debug.show_image_name(image_location)
 
     text = pytesseract.image_to_string(
         img.open(image_location)

--- a/Modules/data_transfer_service.py
+++ b/Modules/data_transfer_service.py
@@ -11,7 +11,7 @@ def begin():
     debug.set_debug(True)
     initialize_files()
 
-    p = persistor.Persistor()
+    p = persistor.Persistor(False)
 
     photos_names = photo_file_finder.get_photo_names()
 

--- a/Modules/data_transfer_service.py
+++ b/Modules/data_transfer_service.py
@@ -19,6 +19,7 @@ def begin():
         image_data = image_processor.image_data_from_image(photo_name)
 
         if image_data is not None:
+            print "Not None"
             p.append(image_data)
 
 def initialize_files():
@@ -26,7 +27,7 @@ def initialize_files():
     data_file_helper.initialize_data_file()
 
 def image_file_when_debugging():
-    # TODO: What is going on here??
+    # TODO: Unable to update and use GlobalVariables.DEBUG
 
     return GlobalVariables.IMAGE_LOCATION
     #return user_interface.prompt_user_for_location()

--- a/Modules/debug.py
+++ b/Modules/debug.py
@@ -47,16 +47,16 @@ def text_tab(text, tab):
     return space_number * space + text
 
 def list_to_string(item_in_list, current_indentation=0):
-    statement = ""
+    statement = DebugCore.NEWLINE
     for item in item_in_list:
         statement = statement + text_tab(item, current_indentation + 1) + DebugCore.NEWLINE
     return statement
 
 def dict_to_string(dictionary, current_indentation=0):
-    statement = ""
-    for key, value in enumerable(dictionary):
+    statement = DebugCore.NEWLINE
+    for key, value in dictionary.items():
         item = "%s:%s" % (key, value)
-        statement = statement + (item, current_indentation + 1) + DebugCore.NEWLINE
+        statement = statement + text_tab(item, current_indentation + 1) + DebugCore.NEWLINE
     return statement
 
 def print_debug_with_state(statement, ErrorState):
@@ -127,6 +127,19 @@ class ImageTextSearch:
             message = "Get %s: %s" % (attr, obj.__dict__[attr])
             statement = statement + text_tab(message, 1)
 
+        debug_print(statement)
+
+    def show_full_data(self, filled_data):
+        statement = dict_to_string(filled_data)
+        debug_print(statement)
+
+class ImageData:
+
+    def __init__(self):
+        pass
+
+    def show_csv_text(self, joined_text):
+        statement = "Data:" + joined_text
         debug_print(statement)
 
 class ErrorState:

--- a/Modules/debug.py
+++ b/Modules/debug.py
@@ -16,7 +16,7 @@ def set_debug(debug_flag=False):
     DataFileHelper.LOCAL_DEBUG = debug_flag
     Persistor.LOCAL_DEBUG = debug_flag
     PhotoFileFinder.LOCAL_DEBUG = debug_flag
-    ImageTextSearch.LOCAL_DEBUG = debug_flag
+    ImageProcessor.LOCAL_DEBUG = debug_flag
 
 def show_sys_path():
     import sys
@@ -38,8 +38,7 @@ def text_truncate(text):
     return text
 
 def text_truncate_access_location(location):
-    # TODO
-    return location
+    return location # TODO
 
 def text_tab(text, tab):
     space_number = tab * 2
@@ -60,8 +59,16 @@ def dict_to_string(dictionary, current_indentation=0):
     return statement
 
 def print_debug_with_state(statement, ErrorState):
-    # TODO
+    # TODO: When states are enabled
     pass
+
+class Service: #TODO
+
+    def __init__(self):
+        pass
+
+    def show_image_data(self, image_data):
+        pass
 
 class DataFileHelper:
     LOCAL_DEBUG = False
@@ -101,11 +108,15 @@ class PhotoFileFinder:
         statement = statement + list_to_string(observed_photos, 0) + DebugCore.NEWLINE
         debug_print(statement)
 
-class ImageTextSearch:
+class ImageProcessor:
     LOCAL_DEBUG = False
 
     def __init__(self):
         pass
+
+    def show_image_name(self, image_location):
+        statement = "The current photo is:" + image_location
+        debug_print(statement)
 
     def show_set_attributes(self, attr, attr_value):
         debug_print("Set %s: %s" % (attr, attr_value))
@@ -142,8 +153,7 @@ class ImageData:
         statement = "Data:" + joined_text
         debug_print(statement)
 
-class ErrorState:
+class ErrorState:# TODO
 
     def __init__(self, state):
-        # TODO
         pass

--- a/Modules/image_data.py
+++ b/Modules/image_data.py
@@ -13,7 +13,6 @@ class Core:
         "total_amount"
     ]
 
-
 class ImageData:
     MAX_ADDRESS_LENGTH = 10
     LOCAL_DEBUG = False
@@ -44,7 +43,9 @@ class ImageData:
 
         self._normalize_none()
 
-        return ",".join(self.attr_list)
+        text = ",".join(self.attr_list)
+        debug.show_csv_text(text)
+        return
 
     def identifier(self):
         return self._date_time()

--- a/Modules/image_data.py
+++ b/Modules/image_data.py
@@ -34,21 +34,23 @@ class ImageData:
             self._debug_print_attributes()
 
     def as_csv_text(self):
+        self._set_text
+        self._normalize_none()
+
+        text = ",".join(self.attr_list)
+        debug.show_csv_text(text)
+        return text
+
+    def identifier(self):
+        return self._date_time()
+
+    def _set_text(self):
         self.attr_list = [
             self._date_time(),
             self._shorten_address(),
             self.total_amount,
             self.description
         ]
-
-        self._normalize_none()
-
-        text = ",".join(self.attr_list)
-        debug.show_csv_text(text)
-        return
-
-    def identifier(self):
-        return self._date_time()
 
     def _assign_instance_variables(self):
         for attr in Core.ANALYSIS_ATTRIBUTES:


### PR DESCRIPTION
Basically, the Persistor has an internal state called `p_state`, which when `True`, determines that the file to be modified is to be open until told to close. In a `False` state, the Persistor will open the file to read or write. This is suppose to be more reliable because there are fewer things that can go wrong other than having a file open all the time consuming resources. We made this change so that in the future if having a file open permanently makes sense then we have the ability to use that. 

We're also touching up the debugging process and adding additional methods. 