### PR TITLE
[Feature] ImageData can require a description or another attribute

### DIFF
--- a/modules/CLI.py
+++ b/modules/CLI.py
@@ -1,24 +1,25 @@
-from image_data import ImageData
+# from image_data import ImageData
 from debug import DebugCore
+from debug import DebugState
 
 class Query(object):
     DEFAULT_MESSAGE = "dank inputs"
 
-    def query_user(query_message):
+    def query_user(self, query_message):
         if DebugCore.GLOBAL_DEBUG is DebugState.OFF:
             return raw_input(query_message)
         else:
             return self.DEFAULT_MESSAGE
 
-
-class QueryForAdditionalDetails(ImageData, Query):
+class QueryForAdditionalDetails(Query):
     CUSTOM_QUERY = {
         "address": "Do you remember the address for this purchase?",
         "description": "Add a description to your purchase"
     }
 
-    def __init__(self, imagedata_superklass, query_attribute):
-        self.imagedata_superklass = imagedata_superklass
+    def __init__(self, image_data, query_attribute, image_name):
+        self.image_name = image_name
+        self.image_data = image_data
         self.query_attribute = query_attribute
 
     def query(self):
@@ -31,8 +32,8 @@ class QueryForAdditionalDetails(ImageData, Query):
         return """We were unable to determine the %s from the image %s.
         On the date %s, at %s, you spent %s.""" % (
             self.query_attribute,
-            self.imagedata_superklass.image_name,
-            self.imagedata_superklass.date,
-            self.imagedata_superklass.time,
-            self.imagedata_superklass.total_amount
+            self.image_name,
+            self.image_data.date,
+            self.image_data.time,
+            self.image_data.total_amount
         )

--- a/modules/CLI.py
+++ b/modules/CLI.py
@@ -1,0 +1,38 @@
+from image_data import ImageData
+from debug import DebugCore
+
+class Query(object):
+    DEFAULT_MESSAGE = "dank inputs"
+
+    def query_user(query_message):
+        if DebugCore.GLOBAL_DEBUG is DebugState.OFF:
+            return raw_input(query_message)
+        else:
+            return self.DEFAULT_MESSAGE
+
+
+class QueryForAdditionalDetails(ImageData, Query):
+    CUSTOM_QUERY = {
+        "address": "Do you remember the address for this purchase?",
+        "description": "Add a description to your purchase"
+    }
+
+    def __init__(self, imagedata_superklass, query_attribute):
+        self.imagedata_superklass = imagedata_superklass
+        self.query_attribute = query_attribute
+
+    def query(self):
+        return self.query_user(
+            self._query_message() +
+            self.CUSTOM_QUERY[self.query_attribute]
+        )
+
+    def _query_message(self):
+        return """We were unable to determine the %s from the image %s.
+        On the date %s, at %s, you spent %s.""" % (
+            self.query_attribute,
+            self.imagedata_superklass.image_name,
+            self.imagedata_superklass.date,
+            self.imagedata_superklass.time,
+            self.imagedata_superklass.total_amount
+        )

--- a/modules/data_file_manager/persistor.py
+++ b/modules/data_file_manager/persistor.py
@@ -27,7 +27,7 @@ class Persistor:
 
         self.f.close()
 
-    def protected_t_append(self, write_data):
+    def protected_append(self, write_data):
         state = self._temporary_query(write_data)
         if (state is Identification.EXISTS) or (state is Identification.IS_NONE):
             return

--- a/modules/data_transfer_service.py
+++ b/modules/data_transfer_service.py
@@ -1,5 +1,7 @@
-from data_file_manager import data_file_helper, photo_file_finder, persistor
-from pa import image_processor
+from data_file_manager import data_file_helper
+from data_file_manager import photo_file_finder
+from data_file_manager import persistor
+from photo_analyzer import image_processor
 from UI import user_interface
 
 from shared import *
@@ -22,7 +24,7 @@ class DataTransferService:
     def begin(self):
         for photo_name in self.photos_names:
             image_data = image_processor.image_data_from_image(photo_name)
-            self.p.protected_t_append(image_data)
+            self.p.protected_append(image_data)
 
     def _image_file(self):
         if DebugCore.GLOBAL_DEBUG is DebugState.OFF:

--- a/modules/image_data.py
+++ b/modules/image_data.py
@@ -47,6 +47,8 @@ class ImageData(object):
                 self.attr_list[pos] = str(None)
 
 class Builder(ImageData):
+    SUBSTITUTE = "HIT"
+
     def __init__(self, data):
         for attr in ImageDataCore.ANALYSIS_ATTRIBUTES:
             setattr(self, attr, data[attr])
@@ -59,7 +61,7 @@ class Builder(ImageData):
             result = function()
 
             if self._required(value) and result is None:
-                result = "HIT"
+                result = self.SUBSTITUTE
 
             results.append(result)
 
@@ -93,6 +95,9 @@ class Builder(ImageData):
         return self.description
 
     def _required(self, value):
+        if ImageDataBuilder.PRECISION is BuilderRequirements.REQUIRES_COMPLETE:
+            return True
+
         return value == ImageDataBuilder.PRECISION.value
 
     def _privatize(self, method_name):

--- a/modules/image_data.py
+++ b/modules/image_data.py
@@ -9,7 +9,7 @@ debug = debug()
 class ImageData(object):
     MAX_ADDRESS_LENGTH = 10
 
-    def __init__(self, data):
+    def __init__(self, data, image_name):
 
         # data = {
         #     "date": data["date"],
@@ -45,6 +45,9 @@ class ImageData(object):
         for pos, attr in enumerate(self.attr_list):
             if attr is None:
                 self.attr_list[pos] = str(None)
+
+    def _query_user(self):
+        QueryForAdditionalDetails().query()
 
 class Builder(ImageData):
     SUBSTITUTE = "HIT"
@@ -111,3 +114,11 @@ class Builder(ImageData):
         address = address + "..."
 
         return address
+
+class QueryForAdditionalDetails:
+    def __init__(self, attribute, photo_name):
+        self.attribute = attribute
+        self.photo_name = photo_name
+
+    def query(self):
+        pass

--- a/modules/photo_analyzer/image_processor.py
+++ b/modules/photo_analyzer/image_processor.py
@@ -23,11 +23,12 @@ def image_data_from_image(image):
         img.open(image_location)
     )
 
-    return ImageTextSearch(text).analyze()
+    return ImageTextSearch(text, image).analyze()
 
 class ImageTextSearch:
-    def __init__(self, original_text):
+    def __init__(self, original_text, image_name):
         self.original_text = original_text
+        self.image_name = image_name
         self.core_data = dict.fromkeys(ImageDataCore.ANALYSIS_ATTRIBUTES, None)
         self._populate_core_data()
 
@@ -35,7 +36,7 @@ class ImageTextSearch:
         debug.text_and_relevant_text(self.original_text, self.core_data)
         self.core_data.update(debug.append_original_text(self.core_data))
 
-        return ImageData(self.core_data)
+        return ImageData(self.core_data, self.image_name)
 
     def _populate_core_data(self):
         f = Finder(self.original_text)

--- a/modules/prompter.py
+++ b/modules/prompter.py
@@ -1,0 +1,7 @@
+def prompt_user_for_location():
+    import Tkinter as tk
+    from tkFileDialog import askdirectory
+
+    tk_prompt = tk.Tk()
+    tk_prompt.withdraw()
+    return askdirectory()

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -1,3 +1,5 @@
+from enum import Enum
+from collections import OrderedDict
 import os
 
 directory = os.getcwd()
@@ -11,17 +13,32 @@ class GlobalConstants:
     PERSISTED_DATA = 'persisted_data.csv'
     PERSISTED_DATA_PATH = '%s/Data/%s' % (directory, PERSISTED_DATA)
 
-class ImageDataCore:
-    ANALYSIS_ATTRIBUTES = [
-        "date",
-        "time",
-        "address",
-        "total_amount",
-        "description"
-    ]
+class BuilderRequirements(Enum):
+    AS_IS = 0
+    REQUIRES_ADDRESS = 1
+    REQUIRES_DESCRIPTION = 2
+    REQUIRES_COMPLETE = 3
 
+class ImageDataCore:
     PROCESSED_ATTRIBUTES = [
         "date",
         "time",
         "total_amount"
     ]
+
+    UNCERTAIN_ATTRIBUTES = [
+        "address",
+        "description"
+    ]
+
+    ANALYSIS_ATTRIBUTES = PROCESSED_ATTRIBUTES + UNCERTAIN_ATTRIBUTES
+
+class ImageDataBuilder:
+    PRECISION = BuilderRequirements.AS_IS
+
+    BUILDER_ATTRIBUTES = OrderedDict([
+        ("date_time", 0),
+        ("address", 1),
+        ("total_amount", 0),
+        ("description", 2)
+    ])

--- a/modules/usrint/user_interface.py
+++ b/modules/usrint/user_interface.py
@@ -1,18 +1,7 @@
 #!/usr/bin/python2.7
 
-# for file prompt
-import Tkinter as tk
-from tkFileDialog import askdirectory
-
 # for displaying images
 from PIL import ImageTk, Image
-
-def prompt_user_for_location():
-    # exists outside of class
-    tk_prompt = tk.Tk()
-
-    tk_prompt.withdraw()
-    return askdirectory()
 
 class UserInterface:
 

--- a/test/data_file_manager/data_file_helper_test.py
+++ b/test/data_file_manager/data_file_helper_test.py
@@ -1,4 +1,5 @@
-import unittest, pytest
+import unittest
+import pytest
 import os
 
 from ...modules.data_file_manager import data_file_helper
@@ -6,9 +7,6 @@ from ...modules.data_file_manager import data_file_helper
 class TestMethods(unittest.TestCase):
     def test_create_and_destroy_file(self):
         data_file_helper.initialize_data_file()
-
         assert data_file_helper.does_file_exist() == True
-
         data_file_helper.clear_file()
-
         assert data_file_helper.is_file_empty() == True

--- a/test/data_file_manager/persistor_test.py
+++ b/test/data_file_manager/persistor_test.py
@@ -11,6 +11,7 @@ class TestMethods(unittest.TestCase):
         global id1, id2
 
         data_file_helper.initialize_data_file()
+        image_name = "dank_memes.jpg"
 
         id1 = ImageData({
             "date": "07/01/17",
@@ -18,7 +19,7 @@ class TestMethods(unittest.TestCase):
             "address": "None",
             "total_amount": "$2017.21",
             "description": "test data"
-        })
+        }, image_name)
 
         id2 = ImageData({
             "date": "07/01/17",
@@ -26,7 +27,7 @@ class TestMethods(unittest.TestCase):
             "address": "None",
             "total_amount": "$20.17",
             "description": "test data"
-        })
+        }, image_name)
 
     def teardown_method(self, method):
         data_file_helper.clear_file()

--- a/test/image_data_test.py
+++ b/test/image_data_test.py
@@ -1,30 +1,52 @@
 import unittest, pytest
 from ..modules.shared import GlobalConstants
 from ..modules.shared import GlobalVariables
+from ..modules.shared import ImageDataBuilder
+from ..modules.shared import BuilderRequirements
 from ..modules.image_data import ImageData
+from ..modules.image_data import Builder
 
 class TestMethods(unittest.TestCase):
     @classmethod
     def setup_class(cls):
-        global test_data, image_data
+        global test_data
 
-        image_data = ImageData({
+        test_data = {
             "date": "07/01/17",
             "time": "20:48:14",
-            "address": "Address",
+            "address": None,
             "total_amount": "$2017.21",
-            "description": "description"
-        })
+            "description": None
+        }
 
     def test_initialize(self):
-        assert image_data
+        assert ImageData(test_data)
 
-    def test_as_csv_text(self):
-        expected = "070117-20:48:14,Address,$2017.21,description"
+    def test_as_csv_text_with_precision_as_is(self):
+        ImageDataBuilder.PRECISION = BuilderRequirements.AS_IS
+        image_data = ImageData(test_data)
+        expected = "070117-20:48:14,None,$2017.21,None"
+        assert image_data.as_csv_text() == expected
 
+    def test_as_csv_text_with_precision_requires_address(self):
+        ImageDataBuilder.PRECISION = BuilderRequirements.REQUIRES_ADDRESS
+        image_data = ImageData(test_data)
+        expected = "070117-20:48:14,%s,$2017.21,None" % (Builder.SUBSTITUTE)
+        assert image_data.as_csv_text() == expected
+
+    def test_as_csv_text_with_precision_requires_description(self):
+        ImageDataBuilder.PRECISION = BuilderRequirements.REQUIRES_DESCRIPTION
+        image_data = ImageData(test_data)
+        expected = "070117-20:48:14,None,$2017.21,%s" % (Builder.SUBSTITUTE)
+        assert image_data.as_csv_text() == expected
+
+    def test_as_csv_text_with_precision_requires_complete(self):
+        ImageDataBuilder.PRECISION = BuilderRequirements.REQUIRES_COMPLETE
+        image_data = ImageData(test_data)
+        expected = "070117-20:48:14,%s,$2017.21,%s" % (Builder.SUBSTITUTE, Builder.SUBSTITUTE)
         assert image_data.as_csv_text() == expected
 
     def test_identifier(self):
+        image_data = ImageData(test_data)
         expected = "070117-20:48:14"
-
         assert image_data.identifier() == expected

--- a/test/image_data_test.py
+++ b/test/image_data_test.py
@@ -11,16 +11,16 @@ class TestMethods(unittest.TestCase):
         image_data = ImageData({
             "date": "07/01/17",
             "time": "20:48:14",
-            "address": "None",
+            "address": "Address",
             "total_amount": "$2017.21",
-            "description": "test data"
+            "description": "description"
         })
 
-    def test_initializa(self):
+    def test_initialize(self):
         assert image_data
 
     def test_as_csv_text(self):
-        expected = "070117-20:48:14,None,$2017.21,test data"
+        expected = "070117-20:48:14,Address,$2017.21,description"
 
         assert image_data.as_csv_text() == expected
 

--- a/test/image_data_test.py
+++ b/test/image_data_test.py
@@ -9,7 +9,7 @@ from ..modules.image_data import Builder
 class TestMethods(unittest.TestCase):
     @classmethod
     def setup_class(cls):
-        global test_data
+        global test_data, image_name
 
         test_data = {
             "date": "07/01/17",
@@ -19,34 +19,37 @@ class TestMethods(unittest.TestCase):
             "description": None
         }
 
+        image_name = "dank_receipt.jpg"
+
+
     def test_initialize(self):
-        assert ImageData(test_data)
+        assert ImageData(test_data, image_name)
 
     def test_as_csv_text_with_precision_as_is(self):
         ImageDataBuilder.PRECISION = BuilderRequirements.AS_IS
-        image_data = ImageData(test_data)
+        image_data = ImageData(test_data, image_name)
         expected = "070117-20:48:14,None,$2017.21,None"
         assert image_data.as_csv_text() == expected
 
     def test_as_csv_text_with_precision_requires_address(self):
         ImageDataBuilder.PRECISION = BuilderRequirements.REQUIRES_ADDRESS
-        image_data = ImageData(test_data)
+        image_data = ImageData(test_data, image_name)
         expected = "070117-20:48:14,%s,$2017.21,None" % (Builder.SUBSTITUTE)
         assert image_data.as_csv_text() == expected
 
     def test_as_csv_text_with_precision_requires_description(self):
         ImageDataBuilder.PRECISION = BuilderRequirements.REQUIRES_DESCRIPTION
-        image_data = ImageData(test_data)
+        image_data = ImageData(test_data, image_name)
         expected = "070117-20:48:14,None,$2017.21,%s" % (Builder.SUBSTITUTE)
         assert image_data.as_csv_text() == expected
 
     def test_as_csv_text_with_precision_requires_complete(self):
         ImageDataBuilder.PRECISION = BuilderRequirements.REQUIRES_COMPLETE
-        image_data = ImageData(test_data)
+        image_data = ImageData(test_data, image_name)
         expected = "070117-20:48:14,%s,$2017.21,%s" % (Builder.SUBSTITUTE, Builder.SUBSTITUTE)
         assert image_data.as_csv_text() == expected
 
     def test_identifier(self):
-        image_data = ImageData(test_data)
+        image_data = ImageData(test_data, image_name)
         expected = "070117-20:48:14"
         assert image_data.identifier() == expected

--- a/test/image_data_test.py
+++ b/test/image_data_test.py
@@ -4,12 +4,15 @@ from ..modules.shared import GlobalVariables
 from ..modules.shared import ImageDataBuilder
 from ..modules.shared import BuilderRequirements
 from ..modules.image_data import ImageData
-from ..modules.image_data import Builder
+from ..modules.CLI import Query
+from ..modules.debug import DebugCore
+from ..modules.debug import DebugState
 
 class TestMethods(unittest.TestCase):
     @classmethod
     def setup_class(cls):
         global test_data, image_name
+        DebugCore.GLOBAL_DEBUG = DebugState.BASIC
 
         test_data = {
             "date": "07/01/17",
@@ -34,19 +37,19 @@ class TestMethods(unittest.TestCase):
     def test_as_csv_text_with_precision_requires_address(self):
         ImageDataBuilder.PRECISION = BuilderRequirements.REQUIRES_ADDRESS
         image_data = ImageData(test_data, image_name)
-        expected = "070117-20:48:14,%s,$2017.21,None" % (Builder.SUBSTITUTE)
+        expected = "070117-20:48:14,%s,$2017.21,None" % (Query.DEFAULT_MESSAGE)
         assert image_data.as_csv_text() == expected
 
     def test_as_csv_text_with_precision_requires_description(self):
         ImageDataBuilder.PRECISION = BuilderRequirements.REQUIRES_DESCRIPTION
         image_data = ImageData(test_data, image_name)
-        expected = "070117-20:48:14,None,$2017.21,%s" % (Builder.SUBSTITUTE)
+        expected = "070117-20:48:14,None,$2017.21,%s" % (Query.DEFAULT_MESSAGE)
         assert image_data.as_csv_text() == expected
 
     def test_as_csv_text_with_precision_requires_complete(self):
         ImageDataBuilder.PRECISION = BuilderRequirements.REQUIRES_COMPLETE
         image_data = ImageData(test_data, image_name)
-        expected = "070117-20:48:14,%s,$2017.21,%s" % (Builder.SUBSTITUTE, Builder.SUBSTITUTE)
+        expected = "070117-20:48:14,%s,$2017.21,%s" % (Query.DEFAULT_MESSAGE, Query.DEFAULT_MESSAGE)
         assert image_data.as_csv_text() == expected
 
     def test_identifier(self):

--- a/test/photo_analyzer/image_processor_test.py
+++ b/test/photo_analyzer/image_processor_test.py
@@ -38,20 +38,9 @@ class TestMethods(unittest.TestCase):
             """
 
         its = image_processor.ImageTextSearch(text)
-        image_processor.LOCAL_DEBUG = True
 
     def test_analyze(self):
-        attrs = {
-            "date": "07/01/2017",
-            "time": "20:48:14",
-            "address": None,
-            "total_amount": "$2017.21",
-            "description": None,
-        }
-
+        csv_text = "07012017-20:48:14,None,$2017.21,None"
         image_data = its.analyze()
-
         assert isinstance(image_data, ImageData)
-
-        for attr, attr_val in attrs.iteritems():
-            assert(attr_val == image_data.__dict__[attr])
+        assert csv_text, image_data.as_csv_text()

--- a/test/photo_analyzer/image_processor_test.py
+++ b/test/photo_analyzer/image_processor_test.py
@@ -36,8 +36,9 @@ class TestMethods(unittest.TestCase):
 
             $ 291.20
             """
+        image_name = "fank_meme.jpg"
 
-        its = image_processor.ImageTextSearch(text)
+        its = image_processor.ImageTextSearch(text, image_name)
 
     def test_analyze(self):
         csv_text = "07012017-20:48:14,None,$2017.21,None"


### PR DESCRIPTION
Basically, the current infrastructure is okay with elements being `None`. In order to require a description, we have to be able to take the attributes of an `ImageData` object, and determine if it can be `None`, depending on a configuration by the user. Hence, a `ImageDataBuilder.PRECISION` setting of `AS_IS` is fine with elements being `None`, while `REQUIRES_ADDRESS` will, as the name suggests, require an address. 

From here, we can look to query the user via CLI whether they want to add an address or an description.  