### PR TITLE
[Arch] using global states instead of debug states

### DIFF
--- a/modules/CLI.py
+++ b/modules/CLI.py
@@ -1,12 +1,12 @@
 # from image_data import ImageData
-from debug import DebugCore
-from debug import DebugState
+from shared import State
+from shared import GlobalVariables
 
 class Query(object):
     DEFAULT_MESSAGE = None
 
     def query_user(self, query_message):
-        if DebugCore.GLOBAL_DEBUG is DebugState.OFF:
+        if GlobalVariables.STATE is State.NOMINAL:
             return raw_input(query_message)
         else:
             return self.DEFAULT_MESSAGE

--- a/modules/debug.py
+++ b/modules/debug.py
@@ -4,17 +4,20 @@ from functools import wraps
 from shared import GlobalVariables
 from shared import GlobalConstants
 from shared import ImageDataCore
+from shared import State
 
 def can_call(func):
     @wraps(func)
     def respond_depending_on_state(*args):
         klass = args[0]
         state = klass.CALL_STATUS
-        if (state is DebugState.BASIC) and not _is_verbose(func, klass):
+        global_state = GlobalVariables.STATE
+        if (global_state is State.NOMINAL) or (global_state is State.TEST):
+            return
+        elif (global_state is State.DEBUG_BASIC):
             return func(*args)
-        elif (state is DebugState.VERBOSE):
+        elif _is_verbose(func, klass):
             return func(*args)
-        return
 
     return respond_depending_on_state
 
@@ -24,20 +27,14 @@ def _is_verbose(function, klass):
     else:
         return False
 
-class DebugState(Enum):
-    OFF = 0
-    BASIC = 1
-    VERBOSE = 2
-
 class DebugCore:
-    GLOBAL_DEBUG = DebugState.OFF
     DEBUG_COUNTER = 0
     MAX_MESSAGE_LENGTH = 100
     VERBOSE_METHODS = True # FIXME
     NEWLINE = "\n"
 
 class BaseDebug:
-    def set_debug(self, debug_flag=DebugState.OFF):
+    def set_debug(self, debug_flag=State.NOMINAL):
         self.debug_print("Set GLOBAL_DEBUG: %s" % debug_flag.name)
         DebugCore.GLOBAL_DEBUG = debug_flag
         DebugDataFileHelper.CALL_STATUS = debug_flag
@@ -93,7 +90,7 @@ class BaseDebug:
         return statement
 
 class DebugService(BaseDebug): #TODO
-    CALL_STATUS = DebugState.OFF
+    CALL_STATUS = State.NOMINAL
     VERBOSE_METHODS = []
 
     def __init__(self):
@@ -103,7 +100,7 @@ class DebugService(BaseDebug): #TODO
         pass
 
 class DebugDataFileHelper(BaseDebug):
-    CALL_STATUS = DebugState.OFF
+    CALL_STATUS = State.NOMINAL
     VERBOSE_METHODS = []
 
     def __init__(self):
@@ -121,7 +118,7 @@ class DebugDataFileHelper(BaseDebug):
         self.debug_print("File/Dir Created: (success) at %s" % (file_path))
 
 class DebugPersistor(BaseDebug):
-    CALL_STATUS = DebugState.OFF
+    CALL_STATUS = State.NOMINAL
     VERBOSE_METHODS = []
 
     def __init__(self):
@@ -157,7 +154,7 @@ class DebugPersistor(BaseDebug):
         return result.name
 
 class DebugPhotoFileFinder(BaseDebug):
-    CALL_STATUS = DebugState.OFF
+    CALL_STATUS = State.NOMINAL
     VERBOSE_METHODS = []
 
     def __init__(self):
@@ -170,7 +167,7 @@ class DebugPhotoFileFinder(BaseDebug):
         self.debug_print(statement)
 
 class DebugImageProcessor(BaseDebug):
-    CALL_STATUS = DebugState.OFF
+    CALL_STATUS = State.NOMINAL
     VERBOSE_METHODS = [
         "text_and_relevant_text"
     ]
@@ -217,7 +214,7 @@ class DebugImageProcessor(BaseDebug):
         self.debug_print(statement)
 
 class DebugImageData(BaseDebug):
-    CALL_STATUS = DebugState.OFF
+    CALL_STATUS = State.NOMINAL
     VERBOSE_METHODS = []
 
     def __init__(self):

--- a/modules/debug.py
+++ b/modules/debug.py
@@ -38,14 +38,14 @@ class DebugCore:
     NEWLINE = "\n"
 
 class BaseDebug:
-    def set_debug(self, debug_flag=State.NOMINAL):
-        self.debug_print("Set GLOBAL_DEBUG: %s" % debug_flag.name)
-        DebugCore.GLOBAL_DEBUG = debug_flag
-        DebugDataFileHelper.CALL_STATUS = debug_flag
-        DebugPersistor.CALL_STATUS = debug_flag
-        DebugPhotoFileFinder.CALL_STATUS = debug_flag
-        DebugImageProcessor.CALL_STATUS = debug_flag
-        DebugImageData.CALL_STATUS = debug_flag
+    def set_debug(self, state=State.NOMINAL):
+        self.debug_print("Set GLOBAL_DEBUG: %s" % state.name)
+        DebugCore.GLOBAL_DEBUG = state
+        DebugDataFileHelper.CALL_STATUS = state
+        DebugPersistor.CALL_STATUS = state
+        DebugPhotoFileFinder.CALL_STATUS = state
+        DebugImageProcessor.CALL_STATUS = state
+        DebugImageData.CALL_STATUS = state
 
     def show_sys_path(self):
         import sys

--- a/modules/debug.py
+++ b/modules/debug.py
@@ -12,12 +12,16 @@ def can_call(func):
         klass = args[0]
         state = klass.CALL_STATUS
         global_state = GlobalVariables.STATE
-        if (global_state is State.NOMINAL) or (global_state is State.TEST):
+        if (global_state is State.NOMINAL):
+            return
+        elif (global_state is State.TEST):
             return
         elif (global_state is State.DEBUG_BASIC):
             return func(*args)
-        elif _is_verbose(func, klass):
+        elif (global_state is State.DEBUG_VERBOSE) and _is_verbose(func, klass):
             return func(*args)
+        else:
+            return
 
     return respond_depending_on_state
 

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -4,9 +4,16 @@ import os
 
 directory = os.getcwd()
 
+class State(Enum):
+    NOMINAL = 0
+    DEBUG_BASIC = 1
+    DEBUG_VERBOSE = 2
+    TEST = 3
+
 class GlobalVariables:
     RECEIPT_LOCATION = ""
     IMAGE_LOCATION = '%s/test/images' % (directory)
+    STATE = State.NOMINAL
 
 class GlobalConstants:
     PYTESSERACT_LOCATION = '/usr/local/Cellar/tesseract/3.05.01/bin/tesseract'

--- a/test/data_file_manager/persistor_test.py
+++ b/test/data_file_manager/persistor_test.py
@@ -2,7 +2,6 @@ import unittest, pytest
 import os
 from ...modules.data_file_manager import persistor
 
-from ...modules import debug
 from ...modules import shared
 from ...modules.image_data import ImageData
 from ...modules.data_file_manager import data_file_helper
@@ -81,7 +80,7 @@ class TestMethods(unittest.TestCase):
         p.close()
 
     def test_protected_append_with_all_none_does_not_write_to_file(self):
-        debug.DebugCore.GLOBAL_DEBUG = debug.DebugState.BASIC
+        shared.GlobalVariables.STATE = shared.State.DEBUG_BASIC
         p = persistor.Persistor(False)
         none_image_data = ImageData({
             "date": None,

--- a/test/image_data_test.py
+++ b/test/image_data_test.py
@@ -3,16 +3,15 @@ from ..modules.shared import GlobalConstants
 from ..modules.shared import GlobalVariables
 from ..modules.shared import ImageDataBuilder
 from ..modules.shared import BuilderRequirements
+from ..modules.shared import State
 from ..modules.image_data import ImageData
 from ..modules.CLI import Query
-from ..modules.debug import DebugCore
-from ..modules.debug import DebugState
 
 class TestMethods(unittest.TestCase):
     @classmethod
     def setup_class(cls):
         global test_data, image_name
-        DebugCore.GLOBAL_DEBUG = DebugState.BASIC
+        GlobalVariables.STATE = State.TEST
 
         test_data = {
             "date": "07/01/17",


### PR DESCRIPTION
Debug states inform how the entire system works. When I see that a functional module has `import debug`, it seems like a code smell. Hence, I have turned `DebugState` into a global shared `State`.